### PR TITLE
Marks derived files as binaries

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+dist/** binary
+docs/assets/** binary
+docs/dist/** binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,5 @@
 dist/** binary
 docs/assets/** binary
 docs/dist/** binary
+
+fonts/* binary


### PR DESCRIPTION
We may not want these checked in at all, but while they're still in the index we can at least exclude them from `git-diff`.
