### PR TITLE
Update the demo app nav

### DIFF
--- a/dist/template-app/index.html
+++ b/dist/template-app/index.html
@@ -23,30 +23,34 @@
           <div class="pane pane-sm sidebar">
             <nav class="nav-group">
               <h5 class="nav-group-title">Favorites</h5>
-              <a class="nav-group-item active" href="#">
+              <a class="nav-group-item">
                 <span class="icon icon-home"></span>
                 connors
               </a>
-              <a class="nav-group-item" href="#">
+              <span class="nav-group-item active">
+                <span class="icon icon-light-up"></span>
+                Photon
+              </span>
+              <span class="nav-group-item">
                 <span class="icon icon-download"></span>
                 Downloads
-              </a>
-              <a class="nav-group-item" href="#">
+              </span>
+              <span class="nav-group-item">
+                <span class="icon icon-signal"></span>
+                AirDrop
+              </span>
+              <span class="nav-group-item">
+                <span class="icon icon-window"></span>
+                Applications
+              </span>
+              <span class="nav-group-item">
                 <span class="icon icon-folder"></span>
                 Documents
-              </a>
-              <a class="nav-group-item" href="#">
-                <span class="icon icon-signal"></span>
-                AirPlay
-              </a>
-              <a class="nav-group-item" href="#">
-                <span class="icon icon-print"></span>
-                Applications
-              </a>
-              <a class="nav-group-item" href="#">
-                <span class="icon icon-cloud"></span>
+              </span>
+              <span class="nav-group-item">
+                <span class="icon icon-monitor"></span>
                 Desktop
-              </a>
+              </span>
             </nav>
           </div>
 

--- a/dist/template-app/index.html
+++ b/dist/template-app/index.html
@@ -23,10 +23,10 @@
           <div class="pane pane-sm sidebar">
             <nav class="nav-group">
               <h5 class="nav-group-title">Favorites</h5>
-              <a class="nav-group-item">
+              <span class="nav-group-item">
                 <span class="icon icon-home"></span>
                 connors
-              </a>
+              </span>
               <span class="nav-group-item active">
                 <span class="icon icon-light-up"></span>
                 Photon
@@ -36,16 +36,16 @@
                 Downloads
               </span>
               <span class="nav-group-item">
-                <span class="icon icon-signal"></span>
-                AirDrop
+                <span class="icon icon-folder"></span>
+                Documents
               </span>
               <span class="nav-group-item">
                 <span class="icon icon-window"></span>
                 Applications
               </span>
               <span class="nav-group-item">
-                <span class="icon icon-folder"></span>
-                Documents
+                <span class="icon icon-signal"></span>
+                AirDrop
               </span>
               <span class="nav-group-item">
                 <span class="icon icon-monitor"></span>

--- a/docs/demo-app.html
+++ b/docs/demo-app.html
@@ -59,10 +59,10 @@
           <div class="pane pane-sm sidebar">
             <nav class="nav-group">
               <h5 class="nav-group-title">Favorites</h5>
-              <a class="nav-group-item">
+              <span class="nav-group-item">
                 <span class="icon icon-home"></span>
                 connors
-              </a>
+              </span>
               <span class="nav-group-item active">
                 <span class="icon icon-light-up"></span>
                 Photon
@@ -72,16 +72,16 @@
                 Downloads
               </span>
               <span class="nav-group-item">
-                <span class="icon icon-signal"></span>
-                AirDrop
+                <span class="icon icon-folder"></span>
+                Documents
               </span>
               <span class="nav-group-item">
                 <span class="icon icon-window"></span>
                 Applications
               </span>
               <span class="nav-group-item">
-                <span class="icon icon-folder"></span>
-                Documents
+                <span class="icon icon-signal"></span>
+                AirDrop
               </span>
               <span class="nav-group-item">
                 <span class="icon icon-monitor"></span>

--- a/docs/demo-app.html
+++ b/docs/demo-app.html
@@ -64,7 +64,7 @@
                 connors
               </a>
               <span class="nav-group-item active">
-                <span class="icon icon-light-down"></span>
+                <span class="icon icon-light-up"></span>
                 Photon
               </span>
               <span class="nav-group-item">
@@ -72,19 +72,19 @@
                 Downloads
               </span>
               <span class="nav-group-item">
+                <span class="icon icon-signal"></span>
+                AirDrop
+              </span>
+              <span class="nav-group-item">
+                <span class="icon icon-window"></span>
+                Applications
+              </span>
+              <span class="nav-group-item">
                 <span class="icon icon-folder"></span>
                 Documents
               </span>
               <span class="nav-group-item">
-                <span class="icon icon-signal"></span>
-                AirPlay
-              </span>
-              <span class="nav-group-item">
-                <span class="icon icon-print"></span>
-                Applications
-              </span>
-              <span class="nav-group-item">
-                <span class="icon icon-cloud"></span>
+                <span class="icon icon-monitor"></span>
                 Desktop
               </span>
             </nav>


### PR DESCRIPTION
Fixes #16. Updated the demo app's nav to be a bit more appropriate:

<img width="232" alt="screen shot 2015-10-14 at 9 15 31 am" src="https://cloud.githubusercontent.com/assets/874145/10490123/317ad12a-7254-11e5-81e2-0f8e061cea31.png">
