### PR TITLE
Implement OS X Cmd+W to close windows, clicking dock icon to open windows

### DIFF
--- a/dist/template-app/app.js
+++ b/dist/template-app/app.js
@@ -5,20 +5,11 @@ var BrowserWindow = require('browser-window');  // Module to create native brows
 // be closed automatically when the JavaScript object is garbage collected.
 var mainWindow = null;
 
-// Quit when all windows are closed.
-app.on('window-all-closed', function() {
-  // On OS X it is common for applications and their menu bar
-  // to stay active until the user quits explicitly with Cmd + Q
-  if (process.platform != 'darwin') {
-    app.quit();
-  }
-});
-
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
 app.on('ready', function() {
   // Create the browser window.
-  mainWindow = new BrowserWindow({
+  var mainWindow = new BrowserWindow({
     width: 600,
     height: 300,
     'min-width': 500,
@@ -30,14 +21,37 @@ app.on('ready', function() {
   // and load the index.html of the app.
   mainWindow.loadUrl('file://' + __dirname + '/index.html');
 
-  // Open the DevTools.
-  //mainWindow.openDevTools();
-
-  // Emitted when the window is closed.
-  mainWindow.on('closed', function() {
-    // Dereference the window object, usually you would store windows
-    // in an array if your app supports multi windows, this is the time
-    // when you should delete the corresponding element.
-    mainWindow = null;
+  // Quit App
+  // OS X specific (Cmd+Q should quit the App)
+  app.on('before-quit', () => {
+    mainWindow.forceClose = true;
+    console.log('App QUIT');
   });
+
+  // Open App window
+  // OS X specific (Clicking the dock icon opens the App)
+  app.on('activate', () => {
+    mainWindow.show();
+    console.log('App OPENED');
+  });
+
+  // Close App window
+  // OS X specific (Cmd+W should close the window, but not the App)
+  mainWindow.on('close', (e) => {
+    if (mainWindow.forceClose) return;
+    e.preventDefault();
+    mainWindow.hide();
+    console.log('App CLOSED');
+  });
+
+  return mainWindow;
+});
+
+// Quit when all windows are closed.
+app.on('window-all-closed', function() {
+  // On OS X it is common for applications and their menu bar
+  // to stay active until the user quits explicitly with Cmd + Q
+  if (process.platform != 'darwin') {
+    app.quit();
+  }
 });


### PR DESCRIPTION
This updates Photon to implement native OS X Window handling (e.g. Cmd+W closes windows, clicking dock icon opens windows, and Cmd+Q quits the app).

This implements what I proposed in #12.