### PR TITLE
fix height of button groups section on doc

### DIFF
--- a/sass/docs.scss
+++ b/sass/docs.scss
@@ -528,7 +528,7 @@ a {
 }
 
 .button-groups-component {
-  height: 110px;
+  height: 115px;
 }
 
 .forms-component {


### PR DESCRIPTION
The size of the button groups section on documentation is cutting at Firefox.

Before
![selection_003](https://cloud.githubusercontent.com/assets/1280255/10526229/f4dc3d28-735f-11e5-8a1b-0807b1dddc09.png)

After
![selection_004](https://cloud.githubusercontent.com/assets/1280255/10526230/f7ec4b02-735f-11e5-9e9b-1dff111666ac.png)
