### PR TITLE
Add support for a toolbar-input

### DIFF
--- a/sass/bars.scss
+++ b/sass/bars.scss
@@ -65,3 +65,32 @@
     margin-right: 4px;
   }
 }
+
+.toolbar-input {
+  position: relative;
+  overflow: visible;
+  margin: 0;
+  padding: 0;
+
+  > .icon {
+    position: absolute;
+    left: 10px;
+    top: 4px;
+    z-index: 1;
+    opacity: 0.5;
+  }
+
+  > .form-control {
+    padding: 3px 4px 1px 24px;
+    border-radius: 12px;
+    box-shadow: inset 0 1px 2px rgba(0,0,0,0.4);
+
+    &:focus {
+      box-shadow: inset 0 1px 2px rgba(0,0,0,0.4),
+                  3px 3px 0 $focus-input-color,
+                  -3px -3px 0 $focus-input-color,
+                  -3px 3px 0 $focus-input-color,
+                  3px -3px 0 $focus-input-color;
+    }
+  }
+}


### PR DESCRIPTION
Add `toolbar-input`. I couldnt decide on markup for a generic input with inset icon.
This at least partly addresses #14.

**JSFiddle:** http://jsfiddle.net/developit/aqu10kd9/ `*`

##### Preview:
![preview](https://i.gyazo.com/ff70bbf75b7f95d19e8546eb18364068.gif)

##### Markup:

```html
<label class="toolbar-input">
    <span class="icon icon-search"></span>
    <input type="search" class="form-control" placeholder="Search...">
</label>
```

_`*` the zoom border effect is not included in this PR_
