### PR TITLE
HTML5 Modals

### DIFF
--- a/sass/dialogs.scss
+++ b/sass/dialogs.scss
@@ -1,0 +1,12 @@
+//
+// Dialogs.scss
+// --------------------------------------------------
+
+dialog {
+  padding: 0;
+  background-color: $chrome-color;
+  border: 1px solid #bebebe;
+  border-radius: 6px;
+  box-shadow: 0 0 30px rgba(0,0,0,.1);
+  overflow: hidden;
+}

--- a/sass/photon.scss
+++ b/sass/photon.scss
@@ -13,6 +13,7 @@
 @import "buttons.scss";
 @import "button-groups.scss";
 @import "bars.scss";
+@import "dialogs.scss";
 @import "forms.scss";
 @import "grid.scss";
 @import "images.scss";


### PR DESCRIPTION
This addresses #8 by adding default photon styling to the HTML5 `<dialog>` element.
#### Rationale:

`<dialog>` provides keyboard shortcuts and backdrop styling, and includes DOM methods to control modal behavor:

| Method | Description |
| --- | --- |
| `showModal()` | Show the dialog with a backdrop preventing further interaction |
| `show()` | Show the dialog but allow interaction with any partial obscured content |
| `close(result)` | close the dialog. Accepts a value, which is passed on to the `close` event that is emitted |
#### JSFiddle Demo:

http://jsfiddle.net/developit/ymx5qev6/
#### Preview:

![preview](https://i.gyazo.com/439c774c5d47da7fa8cdf0ef00ddf1dc.gif)
