### PR TITLE
Bug/draggable fix

### DIFF
--- a/sass/forms.scss
+++ b/sass/forms.scss
@@ -33,6 +33,7 @@ input[type="checkbox"] {
   border: 1px solid $border-color;
   border-radius: $default-border-radius;
   outline: none;
+  -webkit-app-region: no-drag;
 
   &:focus {
     border-color: $focus-input-color;

--- a/sass/utilities.scss
+++ b/sass/utilities.scss
@@ -111,6 +111,11 @@
   -webkit-app-region: drag;
 }
 
+// within draggable regions, allow specific elements to be exempted.
+.not-draggable {
+  -webkit-app-region: no-drag;
+}
+
 // Clearfix
 .clearfix {
   @include clearfix();


### PR DESCRIPTION
- Fixes #47 by exempting .form-control from desktop dragging
- Also adds a `.not-draggable` utility class to allow other elements to be exempted as-needed

![preview](https://i.gyazo.com/b872f2ebba6212be089d7bd7865ef488.gif)