### PR TITLE
Cursor-type fix

### DIFF
--- a/sass/forms.scss
+++ b/sass/forms.scss
@@ -3,6 +3,13 @@
 // Adapted from Bootstrap's forms.less (https://github.com/twbs/bootstrap/blob/master/less/forms.less)
 // --------------------------------------------------
 
+input,
+select,
+textarea,
+button {
+  cursor: pointer;
+}
+
 label {
   display: inline-block;
   font-size: $font-size-default;


### PR DESCRIPTION
Would fix the [Issue #55](https://github.com/connors/photon/issues/55) with the cursor-type of form-elements. 