### PR TITLE
Remove title bar on linux

### DIFF
--- a/dist/template-app/app.js
+++ b/dist/template-app/app.js
@@ -24,7 +24,8 @@ app.on('ready', function() {
     'min-width': 500,
     'min-height': 200,
     'accept-first-mouse': true,
-    'title-bar-style': 'hidden'
+    'title-bar-style': 'hidden',
+    'frame': false
   });
 
   // and load the index.html of the app.

--- a/sass/bars.scss
+++ b/sass/bars.scss
@@ -11,6 +11,7 @@
 
 .toolbar-header {
   border-bottom: 1px solid $dark-border-color;
+  -webkit-app-region: drag;
 
   .title {
     margin-top: 1px;


### PR DESCRIPTION
Default title bar were not removed in linux.

Option ``title-bar-style`` only works with OSX: 
https://github.com/atom/electron/blob/master/docs/api/browser-window.md#new-browserwindowoptions


PS: I edited ``app.js`` in ``/dist``, didnt find a source file for it.