### PR TITLE
Add icon path variables for fonts

### DIFF
--- a/sass/icons.scss
+++ b/sass/icons.scss
@@ -1,9 +1,9 @@
 @font-face {
   font-family: "photon-entypo";
-  src: url('../fonts/photon-entypo.eot');
-  src: url('../fonts/photon-entypo.eot?#iefix') format('eot'),
-    url('../fonts/photon-entypo.woff') format('woff'),
-    url('../fonts/photon-entypo.ttf') format('truetype');
+  src: url(quote($font-folder-path + '/photon-entypo.eot'));
+  src: url(quote($font-folder-path + '/photon-entypo.eot?#iefix')) format('eot'),
+    url(quote($font-folder-path + '/photon-entypo.woff')) format('woff'),
+    url(quote($font-folder-path + '/photon-entypo.ttf')) format('truetype');
   font-weight: normal;
   font-style: normal;
 }

--- a/sass/variables.scss
+++ b/sass/variables.scss
@@ -6,6 +6,7 @@
 // --------------------------------------------------
 
 // Try to use the system's font on whatever platform the user is on.
+$font-folder-path: '../fonts';
 $font-family-default: system, -apple-system, ".SFNSDisplay-Regular", "Helvetica Neue", Helvetica, "Segoe UI", sans-serif !default;
 $font-size-default: 13px !default;
 $font-weight: 500 !default;


### PR DESCRIPTION
For someone who may need to import, use and keep the default sass, and config override variable.
Also make the icon color in button equal to the text color.