### PR TITLE
Add feature: icon-text pull-right

### DIFF
--- a/sass/buttons.scss
+++ b/sass/buttons.scss
@@ -112,15 +112,25 @@
   height: 14px;
   margin-top: 1px;
   margin-bottom: 1px;
-  color: #737475;
   font-size: 14px;
   line-height: 1;
 }
 
 // Add the margin next to the icon if there is text in the button too
+// assume 1 icon max in a button only
 .btn .icon-text {
   margin-right: 5px;
+
+  // For the icon is on the right side of the button text
+  //   add the margin to the left of the text
+  &.pull-right {
+    margin-right: 0;
+    margin-left: 5px;
+    float: right;
+  }
 }
+
+
 
 // This utility class add a down arrow icon to the button
 .btn-dropdown:after {


### PR DESCRIPTION
## Add a feature that the icon-text is placed on the right of the text in a button.

Example code: 

``` html
      <footer class="toolbar toolbar-footer">
        <div class="toolbar-actions">
          <button class="btn btn-default">
            <span class="icon icon-text icon-cancel"></span> Cancel
          </button>

          <button class="btn btn-primary pull-right">
            Send <span class="icon icon-text icon-mail pull-right"></span>
          </button>
        </div>
      </footer>
```

Demo:

[![https://gyazo.com/50f35a312eb48ea7000635254ed3011e](https://i.gyazo.com/50f35a312eb48ea7000635254ed3011e.png)](https://gyazo.com/50f35a312eb48ea7000635254ed3011e)
