### PR TITLE
Use local grunt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ before_install:
   - export GEMDIR=$(rvm gemdir)
 
 install:
-  - travis_retry npm install -g grunt-cli
   - travis_retry npm install
   - travis_retry gem install --no-document "jekyll:~>3.0.0" "rouge:~>1.10" "sass:~>3.4"
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Please file a GitHub issue to [report a bug](https://github.com/connors/photon/i
 1. Install node dependencies: `npm install`.
 2. Open the example app: `npm start`.
 
-Modifying source Sass files? Open a second Terminal tab and run `grunt` to kick off a build the compiled `photon.css`.
+Modifying source Sass files? Open a second Terminal tab and run `npm run build` to kick off a build the compiled `photon.css`.
 
 ## Versioning
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Please file a GitHub issue to [report a bug](https://github.com/connors/photon/i
 1. Install node dependencies: `npm install`.
 2. Open the example app: `npm start`.
 
-Modifying source Sass files? Open a second Terminal tab and run `npm run build` to kick off a build the compiled `photon.css`.
+Modifying source Sass files? Open a second Terminal tab and run `npm run build` to kick off a build of the compiled `photon.css`.
 
 ## Versioning
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "electron-prebuilt": "^0.33.3",
     "grunt": "~0.4.5",
     "grunt-banner": "~0.5.0",
+    "grunt-cli": "^0.1.13",
     "grunt-contrib-clean": "~0.6.0",
     "grunt-contrib-compress": "~0.13.0",
     "grunt-contrib-concat": "~0.5.1",
@@ -39,8 +40,5 @@
     "grunt-sed": "twbs/grunt-sed#v0.2.0",
     "load-grunt-tasks": "~3.2.0",
     "time-grunt": "~1.2.0"
-  },
-  "dependencies": {
-    "grunt-cli": "^0.1.13"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "url": "https://github.com/connors/photon/issues"
   },
   "scripts": {
-    "start": "electron dist/template-app"
+    "start": "electron dist/template-app",
+    "build": "grunt"
   },
   "license": "MIT",
   "devDependencies": {
@@ -38,5 +39,8 @@
     "grunt-sed": "twbs/grunt-sed#v0.2.0",
     "load-grunt-tasks": "~3.2.0",
     "time-grunt": "~1.2.0"
+  },
+  "dependencies": {
+    "grunt-cli": "^0.1.13"
   }
 }


### PR DESCRIPTION
This update adds `grunt-cli` to devDependencies, so the user doesn't have to manually install a global version of it. It also simplifies the Travis setup.