### PR TITLE
Better :focus support for .list-group-item

### DIFF
--- a/sass/lists.scss
+++ b/sass/lists.scss
@@ -30,11 +30,18 @@
   &:first-child {
     border-top: 0;
   }
-  
+
   &.active,
-  // `.selected` is deprecated. Use `.active` instead.
   &.selected {
+    background-color: $active-unfocused-color;
+  }
+  
+  &.active:focus,
+  &:focus,
+  // `.selected` is deprecated. Use `.active` instead.
+  &.selected:focus {
     color: #fff;
+    outline: none;
     background-color: $active-color;
   }
 }

--- a/sass/variables.scss
+++ b/sass/variables.scss
@@ -41,6 +41,7 @@ $dark-color: #57acf5 !default;
 
 // Focus and active colors
 $active-color: #116cd6;
+$active-unfocused-color: #dcdcdc;
 $focus-input-color: lighten($primary-color, 10%)  !default;
 
 // Other


### PR DESCRIPTION
Hi.

It would be nice to have more transparent behaviour of list items when they're focusable. Basically, I want they automatically become `.active` when they're focused.

Plus I want to remove outline from focused items.

And, it would be _really nice_ to display active _but unfocused_ items with the grey background used in OS X (see below).
![screen shot 2015-11-26 at 23 00 02](https://cloud.githubusercontent.com/assets/135717/11430614/09a9c24a-9492-11e5-8b3a-6c0a2fd4e407.png)

It's just a matter of cleaner code for developers.