### PR TITLE
Fix radius of outline around focused form inputs

### DIFF
--- a/sass/forms.scss
+++ b/sass/forms.scss
@@ -37,10 +37,7 @@ input[type="checkbox"] {
 
   &:focus {
     border-color: $focus-input-color;
-    box-shadow: 3px 3px 0 $focus-input-color,
-                -3px -3px 0 $focus-input-color,
-                -3px 3px 0 $focus-input-color,
-                3px -3px 0 $focus-input-color;
+    box-shadow: 0 0 0 3px $focus-input-color;
   }
 }
 


### PR DESCRIPTION
I noticed that the border radius of the outline (aka box shadow) was the same as the input itself, which made it look a little weird. So I fixed that.

Before:
![screen shot 2015-12-18 at 15 26 25](https://cloud.githubusercontent.com/assets/2098462/11898978/2f8af400-a59c-11e5-815c-b7c9343f839d.png)

After:
![screen shot 2015-12-18 at 15 28 05](https://cloud.githubusercontent.com/assets/2098462/11898979/33667040-a59c-11e5-8e9a-d141c6a39955.png)
