### PR TITLE
Replacing deprecated loadUrl with loadURL

### DIFF
--- a/dist/template-app/app.js
+++ b/dist/template-app/app.js
@@ -28,7 +28,7 @@ app.on('ready', function() {
   });
 
   // and load the index.html of the app.
-  mainWindow.loadUrl('file://' + __dirname + '/index.html');
+  mainWindow.loadURL('file://' + __dirname + '/index.html');
 
   // Open the DevTools.
   //mainWindow.openDevTools();


### PR DESCRIPTION
Regarding the "(electron) loadUrl is deprecated. Use loadURL instead." message.