### PR TITLE
Allow text to be edited in form inputs

### DIFF
--- a/dist/css/photon.css
+++ b/dist/css/photon.css
@@ -598,6 +598,7 @@ input[type="checkbox"] {
   border: 1px solid #ddd;
   border-radius: 4px;
   outline: none;
+  -webkit-user-select: text;
   -webkit-app-region: no-drag;
 }
 .form-control:focus {

--- a/docs/dist/css/photon.css
+++ b/docs/dist/css/photon.css
@@ -598,6 +598,7 @@ input[type="checkbox"] {
   border: 1px solid #ddd;
   border-radius: 4px;
   outline: none;
+  -webkit-user-select: text;
   -webkit-app-region: no-drag;
 }
 .form-control:focus {

--- a/sass/forms.scss
+++ b/sass/forms.scss
@@ -33,6 +33,7 @@ input[type="checkbox"] {
   border: 1px solid $border-color;
   border-radius: $default-border-radius;
   outline: none;
+  -webkit-user-select: text;
   -webkit-app-region: no-drag;
 
   &:focus {


### PR DESCRIPTION
Fixes #80 by adding `-webkit-user-select: text;` to `.form-control`.

<img width="444" alt="screen shot 2016-02-14 at 3 44 44 pm" src="https://cloud.githubusercontent.com/assets/874145/13037272/e5704924-d331-11e5-9068-42a423d6fb5c.png">