### PR TITLE
Inactive Tab Font Color (Fixes #96)

### DIFF
--- a/sass/tabs.scss
+++ b/sass/tabs.scss
@@ -13,6 +13,7 @@
   padding: 3px;
   font-size: 12px;
   text-align: center;
+  color: lighten($gray-color, 20%);
   border-left: 1px solid #989698;
   @include linear-gradient(#b8b6b8, #b0aeb0);
 
@@ -21,6 +22,7 @@
   }
 
   &.active {
+    color: $gray-color;
     @include linear-gradient(#d4d2d4, #cccacc);
   }
 
@@ -33,7 +35,7 @@
     font-size: 15px;
     line-height: 15px;
     text-align: center;
-    color: #666;
+    color: lighten($gray-color, 20%);
     opacity: 0;
     transition: opacity .1s linear, background-color .1s linear;
     border-radius: 3px;


### PR DESCRIPTION
Change tab font color on inactive tabs to better mirror the OS X tab behavior.  Remove Magic number on `.icon-close-tab`. Fixes #96
<img width="735" alt="screen shot 2016-04-05 at 11 23 40 am" src="https://cloud.githubusercontent.com/assets/1313818/14276877/e6e60caa-fb20-11e5-8b74-7bbdcdae05e7.png">
