### PR TITLE
fix for Electron App

### DIFF
--- a/dist/template-app/app.js
+++ b/dist/template-app/app.js
@@ -1,9 +1,13 @@
-var app = require('app');  // Module to control application life.
-var BrowserWindow = require('browser-window');  // Module to create native browser window.
+const electron = require('electron');
+
+// Module to control application life.
+const app = electron.app;
+// Module to create native browser window.
+const BrowserWindow = electron.BrowserWindow;
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
-var mainWindow = null;
+let mainWindow;
 
 // Quit when all windows are closed.
 app.on('window-all-closed', function() {
@@ -19,12 +23,8 @@ app.on('window-all-closed', function() {
 app.on('ready', function() {
   // Create the browser window.
   mainWindow = new BrowserWindow({
-    width: 600,
-    height: 300,
-    'min-width': 500,
-    'min-height': 200,
-    'accept-first-mouse': true,
-    'title-bar-style': 'hidden'
+    width: 740,
+    height: 470
   });
 
   // and load the index.html of the app.

--- a/dist/template-app/index.html
+++ b/dist/template-app/index.html
@@ -12,11 +12,6 @@
   <body>
     <div class="window">
 
-      <!-- .toolbar-header sits at the top of your app -->
-      <header class="toolbar toolbar-header">
-        <h1 class="title">Photon</h1>
-      </header>
-
       <!-- Your app's content goes inside .window-content -->
       <div class="window-content">
         <div class="pane-group">


### PR DESCRIPTION
## Problems:

1.) running `npm start` in `template-app` throws an error that Module `app` can't be found.

**Versions**: - Node: 6.2.2 - npm: 3.10.3

**Output:**

```
template-app#> npm start
template-app#> electron .

App threw an error during load
Error: Cannot find module 'app'
    at Module._resolveFilename (module.js:438:15)
```

2.) Window Setting: `'title-bar-style': 'hidden' not working. Also the Window content doesn't fit properly.

[![[window bug]](https://github.frapsoft.com/bugfix/photon.jpg)](https://github.frapsoft.com/bugfix/photon.jpg)

More Details can be found here: [frameless-window](https://github.com/electron/electron/blob/master/docs/api/frameless-window.md).
### Bugfix 1:

Run Electron in a [frameless window](https://github.com/electron/electron/blob/master/docs/api/frameless-window.md) and add Drag Support to class `toolbar-header`.

**app.js:**

```
app.on('ready', function() {
  // Create the browser window.
  mainWindow = new BrowserWindow({
    frame: false,
    width: 740,
    height: 470
  });
```

**index.html:**

add: `style="-webkit-app-region: drag"`

```
<header class="toolbar toolbar-header" style="-webkit-app-region: drag">
  <h1 class="title">Photon</h1>
</header>
```

**Problem:** In this case we can move the Window but the close, minimize and maximize buttons are missing and need to be implemented later on.
### Bugfix 2:

Start Electron in a normal Window and delete the HTML toolbar.

**app.js:**

```
app.on('ready', function() {
  // Create the browser window.
  mainWindow = new BrowserWindow({
    width: 740,
    height: 470
  });
```

**index.html:**

delete:

```
<header class="toolbar toolbar-header">
  <h1 class="title">Photon</h1>
</header>
```

Hope this help you guys. And thanks for the awesome Framework for Electron, love it! Keep up with the great work.

Cheers [Maik Ellerbrock](https://github.com/ellerbrock)
