### PR TITLE
Hovering over an icon shows it's name

### DIFF
--- a/docs/components/icons.html
+++ b/docs/components/icons.html
@@ -19,290 +19,290 @@
   </style>
   <body>
     <div class="icon-examples">
-      <span class="icon icon-note"></span>
-      <span class="icon icon-note-beamed"></span>
-      <span class="icon icon-music"></span>
-      <span class="icon icon-search"></span>
-      <span class="icon icon-flashlight"></span>
-      <span class="icon icon-mail"></span>
-      <span class="icon icon-heart"></span>
-      <span class="icon icon-heart-empty"></span>
-      <span class="icon icon-star"></span>
-      <span class="icon icon-star-empty"></span>
-      <span class="icon icon-user"></span>
-      <span class="icon icon-users"></span>
-      <span class="icon icon-user-add"></span>
-      <span class="icon icon-video"></span>
-      <span class="icon icon-picture"></span>
-      <span class="icon icon-camera"></span>
-      <span class="icon icon-layout"></span>
-      <span class="icon icon-menu"></span>
-      <span class="icon icon-check"></span>
-      <span class="icon icon-cancel"></span>
-      <span class="icon icon-cancel-circled"></span>
-      <span class="icon icon-cancel-squared"></span>
-      <span class="icon icon-plus"></span>
-      <span class="icon icon-plus-circled"></span>
-      <span class="icon icon-plus-squared"></span>
-      <span class="icon icon-minus"></span>
-      <span class="icon icon-minus-circled"></span>
-      <span class="icon icon-minus-squared"></span>
-      <span class="icon icon-help"></span>
-      <span class="icon icon-help-circled"></span>
-      <span class="icon icon-info"></span>
-      <span class="icon icon-info-circled"></span>
-      <span class="icon icon-back"></span>
-      <span class="icon icon-home"></span>
-      <span class="icon icon-link"></span>
-      <span class="icon icon-attach"></span>
-      <span class="icon icon-lock"></span>
-      <span class="icon icon-lock-open"></span>
-      <span class="icon icon-eye"></span>
-      <span class="icon icon-tag"></span>
-      <span class="icon icon-bookmark"></span>
-      <span class="icon icon-bookmarks"></span>
-      <span class="icon icon-flag"></span>
-      <span class="icon icon-thumbs-up"></span>
-      <span class="icon icon-thumbs-down"></span>
-      <span class="icon icon-download"></span>
-      <span class="icon icon-upload"></span>
-      <span class="icon icon-upload-cloud"></span>
-      <span class="icon icon-reply"></span>
-      <span class="icon icon-reply-all"></span>
-      <span class="icon icon-forward"></span>
-      <span class="icon icon-quote"></span>
-      <span class="icon icon-code"></span>
-      <span class="icon icon-export"></span>
-      <span class="icon icon-pencil"></span>
-      <span class="icon icon-feather"></span>
-      <span class="icon icon-print"></span>
-      <span class="icon icon-retweet"></span>
-      <span class="icon icon-keyboard"></span>
-      <span class="icon icon-comment"></span>
-      <span class="icon icon-chat"></span>
-      <span class="icon icon-bell"></span>
-      <span class="icon icon-attention"></span>
-      <span class="icon icon-alert"></span>
-      <span class="icon icon-vcard"></span>
-      <span class="icon icon-address"></span>
-      <span class="icon icon-location"></span>
-      <span class="icon icon-map"></span>
-      <span class="icon icon-direction"></span>
-      <span class="icon icon-compass"></span>
-      <span class="icon icon-cup"></span>
-      <span class="icon icon-trash"></span>
-      <span class="icon icon-doc"></span>
-      <span class="icon icon-docs"></span>
-      <span class="icon icon-doc-landscape"></span>
-      <span class="icon icon-doc-text"></span>
-      <span class="icon icon-doc-text-inv"></span>
-      <span class="icon icon-newspaper"></span>
-      <span class="icon icon-book-open"></span>
-      <span class="icon icon-book"></span>
-      <span class="icon icon-folder"></span>
-      <span class="icon icon-archive"></span>
-      <span class="icon icon-box"></span>
-      <span class="icon icon-rss"></span>
-      <span class="icon icon-phone"></span>
-      <span class="icon icon-cog"></span>
-      <span class="icon icon-tools"></span>
-      <span class="icon icon-share"></span>
-      <span class="icon icon-shareable"></span>
-      <span class="icon icon-basket"></span>
-      <span class="icon icon-bag"></span>
-      <span class="icon icon-calendar"></span>
-      <span class="icon icon-login"></span>
-      <span class="icon icon-logout"></span>
-      <span class="icon icon-mic"></span>
-      <span class="icon icon-mute"></span>
-      <span class="icon icon-sound"></span>
-      <span class="icon icon-volume"></span>
-      <span class="icon icon-clock"></span>
-      <span class="icon icon-hourglass"></span>
-      <span class="icon icon-lamp"></span>
-      <span class="icon icon-light-down"></span>
-      <span class="icon icon-light-up"></span>
-      <span class="icon icon-adjust"></span>
-      <span class="icon icon-block"></span>
-      <span class="icon icon-resize-full"></span>
-      <span class="icon icon-resize-small"></span>
-      <span class="icon icon-popup"></span>
-      <span class="icon icon-publish"></span>
-      <span class="icon icon-window"></span>
-      <span class="icon icon-arrow-combo"></span>
-      <span class="icon icon-down-circled"></span>
-      <span class="icon icon-left-circled"></span>
-      <span class="icon icon-right-circled"></span>
-      <span class="icon icon-up-circled"></span>
-      <span class="icon icon-down-open"></span>
-      <span class="icon icon-left-open"></span>
-      <span class="icon icon-right-open"></span>
-      <span class="icon icon-up-open"></span>
-      <span class="icon icon-down-open-mini"></span>
-      <span class="icon icon-left-open-mini"></span>
-      <span class="icon icon-right-open-mini"></span>
-      <span class="icon icon-up-open-mini"></span>
-      <span class="icon icon-down-open-big"></span>
-      <span class="icon icon-left-open-big"></span>
-      <span class="icon icon-right-open-big"></span>
-      <span class="icon icon-up-open-big"></span>
-      <span class="icon icon-down"></span>
-      <span class="icon icon-left"></span>
-      <span class="icon icon-right"></span>
-      <span class="icon icon-up"></span>
-      <span class="icon icon-down-dir"></span>
-      <span class="icon icon-left-dir"></span>
-      <span class="icon icon-right-dir"></span>
-      <span class="icon icon-up-dir"></span>
-      <span class="icon icon-down-bold"></span>
-      <span class="icon icon-left-bold"></span>
-      <span class="icon icon-right-bold"></span>
-      <span class="icon icon-up-bold"></span>
-      <span class="icon icon-down-thin"></span>
-      <span class="icon icon-left-thin"></span>
-      <span class="icon icon-right-thin"></span>
-      <span class="icon icon-up-thin"></span>
-      <span class="icon icon-ccw"></span>
-      <span class="icon icon-cw"></span>
-      <span class="icon icon-arrows-ccw"></span>
-      <span class="icon icon-level-down"></span>
-      <span class="icon icon-level-up"></span>
-      <span class="icon icon-shuffle"></span>
-      <span class="icon icon-loop"></span>
-      <span class="icon icon-switch"></span>
-      <span class="icon icon-play"></span>
-      <span class="icon icon-stop"></span>
-      <span class="icon icon-pause"></span>
-      <span class="icon icon-record"></span>
-      <span class="icon icon-to-end"></span>
-      <span class="icon icon-to-start"></span>
-      <span class="icon icon-fast-forward"></span>
-      <span class="icon icon-fast-backward"></span>
-      <span class="icon icon-progress-0"></span>
-      <span class="icon icon-progress-1"></span>
-      <span class="icon icon-progress-2"></span>
-      <span class="icon icon-progress-3"></span>
-      <span class="icon icon-target"></span>
-      <span class="icon icon-palette"></span>
-      <span class="icon icon-list"></span>
-      <span class="icon icon-list-add"></span>
-      <span class="icon icon-signal"></span>
-      <span class="icon icon-trophy"></span>
-      <span class="icon icon-battery"></span>
-      <span class="icon icon-back-in-time"></span>
-      <span class="icon icon-monitor"></span>
-      <span class="icon icon-mobile"></span>
-      <span class="icon icon-network"></span>
-      <span class="icon icon-cd"></span>
-      <span class="icon icon-inbox"></span>
-      <span class="icon icon-install"></span>
-      <span class="icon icon-globe"></span>
-      <span class="icon icon-cloud"></span>
-      <span class="icon icon-cloud-thunder"></span>
-      <span class="icon icon-flash"></span>
-      <span class="icon icon-moon"></span>
-      <span class="icon icon-flight"></span>
-      <span class="icon icon-paper-plane"></span>
-      <span class="icon icon-leaf"></span>
-      <span class="icon icon-lifebuoy"></span>
-      <span class="icon icon-mouse"></span>
-      <span class="icon icon-briefcase"></span>
-      <span class="icon icon-suitcase"></span>
-      <span class="icon icon-dot"></span>
-      <span class="icon icon-dot-2"></span>
-      <span class="icon icon-dot-3"></span>
-      <span class="icon icon-brush"></span>
-      <span class="icon icon-magnet"></span>
-      <span class="icon icon-infinity"></span>
-      <span class="icon icon-erase"></span>
-      <span class="icon icon-chart-pie"></span>
-      <span class="icon icon-chart-line"></span>
-      <span class="icon icon-chart-bar"></span>
-      <span class="icon icon-chart-area"></span>
-      <span class="icon icon-tape"></span>
-      <span class="icon icon-graduation-cap"></span>
-      <span class="icon icon-language"></span>
-      <span class="icon icon-ticket"></span>
-      <span class="icon icon-water"></span>
-      <span class="icon icon-droplet"></span>
-      <span class="icon icon-air"></span>
-      <span class="icon icon-credit-card"></span>
-      <span class="icon icon-floppy"></span>
-      <span class="icon icon-clipboard"></span>
-      <span class="icon icon-megaphone"></span>
-      <span class="icon icon-database"></span>
-      <span class="icon icon-drive"></span>
-      <span class="icon icon-bucket"></span>
-      <span class="icon icon-thermometer"></span>
-      <span class="icon icon-key"></span>
-      <span class="icon icon-flow-cascade"></span>
-      <span class="icon icon-flow-branch"></span>
-      <span class="icon icon-flow-tree"></span>
-      <span class="icon icon-flow-line"></span>
-      <span class="icon icon-flow-parallel"></span>
-      <span class="icon icon-rocket"></span>
-      <span class="icon icon-gauge"></span>
-      <span class="icon icon-traffic-cone"></span>
-      <span class="icon icon-cc"></span>
-      <span class="icon icon-cc-by"></span>
-      <span class="icon icon-cc-nc"></span>
-      <span class="icon icon-cc-nc-eu"></span>
-      <span class="icon icon-cc-nc-jp"></span>
-      <span class="icon icon-cc-sa"></span>
-      <span class="icon icon-cc-nd"></span>
-      <span class="icon icon-cc-pd"></span>
-      <span class="icon icon-cc-zero"></span>
-      <span class="icon icon-cc-share"></span>
-      <span class="icon icon-cc-remix"></span>
-      <span class="icon icon-github"></span>
-      <span class="icon icon-github-circled"></span>
-      <span class="icon icon-flickr"></span>
-      <span class="icon icon-flickr-circled"></span>
-      <span class="icon icon-vimeo"></span>
-      <span class="icon icon-vimeo-circled"></span>
-      <span class="icon icon-twitter"></span>
-      <span class="icon icon-twitter-circled"></span>
-      <span class="icon icon-facebook"></span>
-      <span class="icon icon-facebook-circled"></span>
-      <span class="icon icon-facebook-squared"></span>
-      <span class="icon icon-gplus"></span>
-      <span class="icon icon-gplus-circled"></span>
-      <span class="icon icon-pinterest"></span>
-      <span class="icon icon-pinterest-circled"></span>
-      <span class="icon icon-tumblr"></span>
-      <span class="icon icon-tumblr-circled"></span>
-      <span class="icon icon-linkedin"></span>
-      <span class="icon icon-linkedin-circled"></span>
-      <span class="icon icon-dribbble"></span>
-      <span class="icon icon-dribbble-circled"></span>
-      <span class="icon icon-stumbleupon"></span>
-      <span class="icon icon-stumbleupon-circled"></span>
-      <span class="icon icon-lastfm"></span>
-      <span class="icon icon-lastfm-circled"></span>
-      <span class="icon icon-rdio"></span>
-      <span class="icon icon-rdio-circled"></span>
-      <span class="icon icon-spotify"></span>
-      <span class="icon icon-spotify-circled"></span>
-      <span class="icon icon-qq"></span>
-      <span class="icon icon-instagram"></span>
-      <span class="icon icon-dropbox"></span>
-      <span class="icon icon-evernote"></span>
-      <span class="icon icon-flattr"></span>
-      <span class="icon icon-skype"></span>
-      <span class="icon icon-skype-circled"></span>
-      <span class="icon icon-renren"></span>
-      <span class="icon icon-sina-weibo"></span>
-      <span class="icon icon-paypal"></span>
-      <span class="icon icon-picasa"></span>
-      <span class="icon icon-soundcloud"></span>
-      <span class="icon icon-mixi"></span>
-      <span class="icon icon-behance"></span>
-      <span class="icon icon-google-circles"></span>
-      <span class="icon icon-vkontakte"></span>
-      <span class="icon icon-smashing"></span>
-      <span class="icon icon-sweden"></span>
-      <span class="icon icon-db-shape"></span>
-      <span class="icon icon-logo-db"></span>
+      <span class="icon icon-note" title="icon-note"></span>
+      <span class="icon icon-note-beamed" title="icon-note-beamed"></span>
+      <span class="icon icon-music" title="icon-music"></span>
+      <span class="icon icon-search" title="icon-search"></span>
+      <span class="icon icon-flashlight" title="icon-flashlight"></span>
+      <span class="icon icon-mail" title="icon-mail"></span>
+      <span class="icon icon-heart" title="icon-heart"></span>
+      <span class="icon icon-heart-empty" title="icon-heart-empty"></span>
+      <span class="icon icon-star" title="icon-star"></span>
+      <span class="icon icon-star-empty" title="icon-star-empty"></span>
+      <span class="icon icon-user" title="icon-user"></span>
+      <span class="icon icon-users" title="icon-users"></span>
+      <span class="icon icon-user-add" title="icon-user-add"></span>
+      <span class="icon icon-video" title="icon-video"></span>
+      <span class="icon icon-picture" title="icon-picture"></span>
+      <span class="icon icon-camera" title="icon-camera"></span>
+      <span class="icon icon-layout" title="icon-layout"></span>
+      <span class="icon icon-menu" title="icon-menu"></span>
+      <span class="icon icon-check" title="icon-check"></span>
+      <span class="icon icon-cancel" title="icon-cancel"></span>
+      <span class="icon icon-cancel-circled" title="icon-cancel-circled"></span>
+      <span class="icon icon-cancel-squared" title="icon-cancel-squared"></span>
+      <span class="icon icon-plus" title="icon-plus"></span>
+      <span class="icon icon-plus-circled" title="icon-plus-circled"></span>
+      <span class="icon icon-plus-squared" title="icon-plus-squared"></span>
+      <span class="icon icon-minus" title="icon-minus"></span>
+      <span class="icon icon-minus-circled" title="icon-minus-circled"></span>
+      <span class="icon icon-minus-squared" title="icon-minus-squared"></span>
+      <span class="icon icon-help" title="icon-help"></span>
+      <span class="icon icon-help-circled" title="icon-help-circled"></span>
+      <span class="icon icon-info" title="icon-info"></span>
+      <span class="icon icon-info-circled" title="icon-info-circled"></span>
+      <span class="icon icon-back" title="icon-back"></span>
+      <span class="icon icon-home" title="icon-home"></span>
+      <span class="icon icon-link" title="icon-link"></span>
+      <span class="icon icon-attach" title="icon-attach"></span>
+      <span class="icon icon-lock" title="icon-lock"></span>
+      <span class="icon icon-lock-open" title="icon-lock-open"></span>
+      <span class="icon icon-eye" title="icon-eye"></span>
+      <span class="icon icon-tag" title="icon-tag"></span>
+      <span class="icon icon-bookmark" title="icon-bookmark"></span>
+      <span class="icon icon-bookmarks" title="icon-bookmarks"></span>
+      <span class="icon icon-flag" title="icon-flag"></span>
+      <span class="icon icon-thumbs-up" title="icon-thumbs-up"></span>
+      <span class="icon icon-thumbs-down" title="icon-thumbs-down"></span>
+      <span class="icon icon-download" title="icon-download"></span>
+      <span class="icon icon-upload" title="icon-upload"></span>
+      <span class="icon icon-upload-cloud" title="icon-upload-cloud"></span>
+      <span class="icon icon-reply" title="icon-reply"></span>
+      <span class="icon icon-reply-all" title="icon-reply-all"></span>
+      <span class="icon icon-forward" title="icon-forward"></span>
+      <span class="icon icon-quote" title="icon-quote"></span>
+      <span class="icon icon-code" title="icon-code"></span>
+      <span class="icon icon-export" title="icon-export"></span>
+      <span class="icon icon-pencil" title="icon-pencil"></span>
+      <span class="icon icon-feather" title="icon-feather"></span>
+      <span class="icon icon-print" title="icon-print"></span>
+      <span class="icon icon-retweet" title="icon-retweet"></span>
+      <span class="icon icon-keyboard" title="icon-keyboard"></span>
+      <span class="icon icon-comment" title="icon-comment"></span>
+      <span class="icon icon-chat" title="icon-chat"></span>
+      <span class="icon icon-bell" title="icon-bell"></span>
+      <span class="icon icon-attention" title="icon-attention"></span>
+      <span class="icon icon-alert" title="icon-alert"></span>
+      <span class="icon icon-vcard" title="icon-vcard"></span>
+      <span class="icon icon-address" title="icon-address"></span>
+      <span class="icon icon-location" title="icon-location"></span>
+      <span class="icon icon-map" title="icon-map"></span>
+      <span class="icon icon-direction" title="icon-direction"></span>
+      <span class="icon icon-compass" title="icon-compass"></span>
+      <span class="icon icon-cup" title="icon-cup"></span>
+      <span class="icon icon-trash" title="icon-trash"></span>
+      <span class="icon icon-doc" title="icon-doc"></span>
+      <span class="icon icon-docs" title="icon-docs"></span>
+      <span class="icon icon-doc-landscape" title="icon-doc-landscape"></span>
+      <span class="icon icon-doc-text" title="icon-doc-text"></span>
+      <span class="icon icon-doc-text-inv" title="icon-doc-text-inv"></span>
+      <span class="icon icon-newspaper" title="icon-newspaper"></span>
+      <span class="icon icon-book-open" title="icon-book-open"></span>
+      <span class="icon icon-book" title="icon-book"></span>
+      <span class="icon icon-folder" title="icon-folder"></span>
+      <span class="icon icon-archive" title="icon-archive"></span>
+      <span class="icon icon-box" title="icon-box"></span>
+      <span class="icon icon-rss" title="icon-rss"></span>
+      <span class="icon icon-phone" title="icon-phone"></span>
+      <span class="icon icon-cog" title="icon-cog"></span>
+      <span class="icon icon-tools" title="icon-tools"></span>
+      <span class="icon icon-share" title="icon-share"></span>
+      <span class="icon icon-shareable" title="icon-shareable"></span>
+      <span class="icon icon-basket" title="icon-basket"></span>
+      <span class="icon icon-bag" title="icon-bag"></span>
+      <span class="icon icon-calendar" title="icon-calendar"></span>
+      <span class="icon icon-login" title="icon-login"></span>
+      <span class="icon icon-logout" title="icon-logout"></span>
+      <span class="icon icon-mic" title="icon-mic"></span>
+      <span class="icon icon-mute" title="icon-mute"></span>
+      <span class="icon icon-sound" title="icon-sound"></span>
+      <span class="icon icon-volume" title="icon-volume"></span>
+      <span class="icon icon-clock" title="icon-clock"></span>
+      <span class="icon icon-hourglass" title="icon-hourglass"></span>
+      <span class="icon icon-lamp" title="icon-lamp"></span>
+      <span class="icon icon-light-down" title="icon-light-down"></span>
+      <span class="icon icon-light-up" title="icon-light-up"></span>
+      <span class="icon icon-adjust" title="icon-adjust"></span>
+      <span class="icon icon-block" title="icon-block"></span>
+      <span class="icon icon-resize-full" title="icon-resize-full"></span>
+      <span class="icon icon-resize-small" title="icon-resize-small"></span>
+      <span class="icon icon-popup" title="icon-popup"></span>
+      <span class="icon icon-publish" title="icon-publish"></span>
+      <span class="icon icon-window" title="icon-window"></span>
+      <span class="icon icon-arrow-combo" title="icon-arrow-combo"></span>
+      <span class="icon icon-down-circled" title="icon-down-circled"></span>
+      <span class="icon icon-left-circled" title="icon-left-circled"></span>
+      <span class="icon icon-right-circled" title="icon-right-circled"></span>
+      <span class="icon icon-up-circled" title="icon-up-circled"></span>
+      <span class="icon icon-down-open" title="icon-down-open"></span>
+      <span class="icon icon-left-open" title="icon-left-open"></span>
+      <span class="icon icon-right-open" title="icon-right-open"></span>
+      <span class="icon icon-up-open" title="icon-up-open"></span>
+      <span class="icon icon-down-open-mini" title="icon-down-open-mini"></span>
+      <span class="icon icon-left-open-mini" title="icon-left-open-mini"></span>
+      <span class="icon icon-right-open-mini" title="icon-right-open-mini"></span>
+      <span class="icon icon-up-open-mini" title="icon-up-open-mini"></span>
+      <span class="icon icon-down-open-big" title="icon-down-open-big"></span>
+      <span class="icon icon-left-open-big" title="icon-left-open-big"></span>
+      <span class="icon icon-right-open-big" title="icon-right-open-big"></span>
+      <span class="icon icon-up-open-big" title="icon-up-open-big"></span>
+      <span class="icon icon-down" title="icon-down"></span>
+      <span class="icon icon-left" title="icon-left"></span>
+      <span class="icon icon-right" title="icon-right"></span>
+      <span class="icon icon-up" title="icon-up"></span>
+      <span class="icon icon-down-dir" title="icon-down-dir"></span>
+      <span class="icon icon-left-dir" title="icon-left-dir"></span>
+      <span class="icon icon-right-dir" title="icon-right-dir"></span>
+      <span class="icon icon-up-dir" title="icon-up-dir"></span>
+      <span class="icon icon-down-bold" title="icon-down-bold"></span>
+      <span class="icon icon-left-bold" title="icon-left-bold"></span>
+      <span class="icon icon-right-bold" title="icon-right-bold"></span>
+      <span class="icon icon-up-bold" title="icon-up-bold"></span>
+      <span class="icon icon-down-thin" title="icon-down-thin"></span>
+      <span class="icon icon-left-thin" title="icon-left-thin"></span>
+      <span class="icon icon-right-thin" title="icon-right-thin"></span>
+      <span class="icon icon-up-thin" title="icon-up-thin"></span>
+      <span class="icon icon-ccw" title="icon-ccw"></span>
+      <span class="icon icon-cw" title="icon-cw"></span>
+      <span class="icon icon-arrows-ccw" title="icon-arrows-ccw"></span>
+      <span class="icon icon-level-down" title="icon-level-down"></span>
+      <span class="icon icon-level-up" title="icon-level-up"></span>
+      <span class="icon icon-shuffle" title="icon-shuffle"></span>
+      <span class="icon icon-loop" title="icon-loop"></span>
+      <span class="icon icon-switch" title="icon-switch"></span>
+      <span class="icon icon-play" title="icon-play"></span>
+      <span class="icon icon-stop" title="icon-stop"></span>
+      <span class="icon icon-pause" title="icon-pause"></span>
+      <span class="icon icon-record" title="icon-record"></span>
+      <span class="icon icon-to-end" title="icon-to-end"></span>
+      <span class="icon icon-to-start" title="icon-to-start"></span>
+      <span class="icon icon-fast-forward" title="icon-fast-forward"></span>
+      <span class="icon icon-fast-backward" title="icon-fast-backward"></span>
+      <span class="icon icon-progress-0" title="icon-progress-0"></span>
+      <span class="icon icon-progress-1" title="icon-progress-1"></span>
+      <span class="icon icon-progress-2" title="icon-progress-2"></span>
+      <span class="icon icon-progress-3" title="icon-progress-3"></span>
+      <span class="icon icon-target" title="icon-target"></span>
+      <span class="icon icon-palette" title="icon-palette"></span>
+      <span class="icon icon-list" title="icon-list"></span>
+      <span class="icon icon-list-add" title="icon-list-add"></span>
+      <span class="icon icon-signal" title="icon-signal"></span>
+      <span class="icon icon-trophy" title="icon-trophy"></span>
+      <span class="icon icon-battery" title="icon-battery"></span>
+      <span class="icon icon-back-in-time" title="icon-back-in-time"></span>
+      <span class="icon icon-monitor" title="icon-monitor"></span>
+      <span class="icon icon-mobile" title="icon-mobile"></span>
+      <span class="icon icon-network" title="icon-network"></span>
+      <span class="icon icon-cd" title="icon-cd"></span>
+      <span class="icon icon-inbox" title="icon-inbox"></span>
+      <span class="icon icon-install" title="icon-install"></span>
+      <span class="icon icon-globe" title="icon-globe"></span>
+      <span class="icon icon-cloud" title="icon-cloud"></span>
+      <span class="icon icon-cloud-thunder" title="icon-cloud-thunder"></span>
+      <span class="icon icon-flash" title="icon-flash"></span>
+      <span class="icon icon-moon" title="icon-moon"></span>
+      <span class="icon icon-flight" title="icon-flight"></span>
+      <span class="icon icon-paper-plane" title="icon-paper-plane"></span>
+      <span class="icon icon-leaf" title="icon-leaf"></span>
+      <span class="icon icon-lifebuoy" title="icon-lifebuoy"></span>
+      <span class="icon icon-mouse" title="icon-mouse"></span>
+      <span class="icon icon-briefcase" title="icon-briefcase"></span>
+      <span class="icon icon-suitcase" title="icon-suitcase"></span>
+      <span class="icon icon-dot" title="icon-dot"></span>
+      <span class="icon icon-dot-2" title="icon-dot-2"></span>
+      <span class="icon icon-dot-3" title="icon-dot-3"></span>
+      <span class="icon icon-brush" title="icon-brush"></span>
+      <span class="icon icon-magnet" title="icon-magnet"></span>
+      <span class="icon icon-infinity" title="icon-infinity"></span>
+      <span class="icon icon-erase" title="icon-erase"></span>
+      <span class="icon icon-chart-pie" title="icon-chart-pie"></span>
+      <span class="icon icon-chart-line" title="icon-chart-line"></span>
+      <span class="icon icon-chart-bar" title="icon-chart-bar"></span>
+      <span class="icon icon-chart-area" title="icon-chart-area"></span>
+      <span class="icon icon-tape" title="icon-tape"></span>
+      <span class="icon icon-graduation-cap" title="icon-graduation-cap"></span>
+      <span class="icon icon-language" title="icon-language"></span>
+      <span class="icon icon-ticket" title="icon-ticket"></span>
+      <span class="icon icon-water" title="icon-water"></span>
+      <span class="icon icon-droplet" title="icon-droplet"></span>
+      <span class="icon icon-air" title="icon-air"></span>
+      <span class="icon icon-credit-card" title="icon-credit-card"></span>
+      <span class="icon icon-floppy" title="icon-floppy"></span>
+      <span class="icon icon-clipboard" title="icon-clipboard"></span>
+      <span class="icon icon-megaphone" title="icon-megaphone"></span>
+      <span class="icon icon-database" title="icon-database"></span>
+      <span class="icon icon-drive" title="icon-drive"></span>
+      <span class="icon icon-bucket" title="icon-bucket"></span>
+      <span class="icon icon-thermometer" title="icon-thermometer"></span>
+      <span class="icon icon-key" title="icon-key"></span>
+      <span class="icon icon-flow-cascade" title="icon-flow-cascade"></span>
+      <span class="icon icon-flow-branch" title="icon-flow-branch"></span>
+      <span class="icon icon-flow-tree" title="icon-flow-tree"></span>
+      <span class="icon icon-flow-line" title="icon-flow-line"></span>
+      <span class="icon icon-flow-parallel" title="icon-flow-parallel"></span>
+      <span class="icon icon-rocket" title="icon-rocket"></span>
+      <span class="icon icon-gauge" title="icon-gauge"></span>
+      <span class="icon icon-traffic-cone" title="icon-traffic-cone"></span>
+      <span class="icon icon-cc" title="icon-cc"></span>
+      <span class="icon icon-cc-by" title="icon-cc-by"></span>
+      <span class="icon icon-cc-nc" title="icon-cc-nc"></span>
+      <span class="icon icon-cc-nc-eu" title="icon-cc-nc-eu"></span>
+      <span class="icon icon-cc-nc-jp" title="icon-cc-nc-jp"></span>
+      <span class="icon icon-cc-sa" title="icon-cc-sa"></span>
+      <span class="icon icon-cc-nd" title="icon-cc-nd"></span>
+      <span class="icon icon-cc-pd" title="icon-cc-pd"></span>
+      <span class="icon icon-cc-zero" title="icon-cc-zero"></span>
+      <span class="icon icon-cc-share" title="icon-cc-share"></span>
+      <span class="icon icon-cc-remix" title="icon-cc-remix"></span>
+      <span class="icon icon-github" title="icon-github"></span>
+      <span class="icon icon-github-circled" title="icon-github-circled"></span>
+      <span class="icon icon-flickr" title="icon-flickr"></span>
+      <span class="icon icon-flickr-circled" title="icon-flickr-circled"></span>
+      <span class="icon icon-vimeo" title="icon-vimeo"></span>
+      <span class="icon icon-vimeo-circled" title="icon-vimeo-circled"></span>
+      <span class="icon icon-twitter" title="icon-twitter"></span>
+      <span class="icon icon-twitter-circled" title="icon-twitter-circled"></span>
+      <span class="icon icon-facebook" title="icon-facebook"></span>
+      <span class="icon icon-facebook-circled" title="icon-facebook-circled"></span>
+      <span class="icon icon-facebook-squared" title="icon-facebook-squared"></span>
+      <span class="icon icon-gplus" title="icon-gplus"></span>
+      <span class="icon icon-gplus-circled" title="icon-gplus-circled"></span>
+      <span class="icon icon-pinterest" title="icon-pinterest"></span>
+      <span class="icon icon-pinterest-circled" title="icon-pinterest-circled"></span>
+      <span class="icon icon-tumblr" title="icon-tumblr"></span>
+      <span class="icon icon-tumblr-circled" title="icon-tumblr-circled"></span>
+      <span class="icon icon-linkedin" title="icon-linkedin"></span>
+      <span class="icon icon-linkedin-circled" title="icon-linkedin-circled"></span>
+      <span class="icon icon-dribbble" title="icon-dribbble"></span>
+      <span class="icon icon-dribbble-circled" title="icon-dribbble-circled"></span>
+      <span class="icon icon-stumbleupon" title="icon-stumbleupon"></span>
+      <span class="icon icon-stumbleupon-circled" title="icon-stumbleupon-circled"></span>
+      <span class="icon icon-lastfm" title="icon-lastfm"></span>
+      <span class="icon icon-lastfm-circled" title="icon-lastfm-circled"></span>
+      <span class="icon icon-rdio" title="icon-rdio"></span>
+      <span class="icon icon-rdio-circled" title="icon-rdio-circled"></span>
+      <span class="icon icon-spotify" title="icon-spotify"></span>
+      <span class="icon icon-spotify-circled" title="icon-spotify-circled"></span>
+      <span class="icon icon-qq" title="icon-qq"></span>
+      <span class="icon icon-instagram" title="icon-instagram"></span>
+      <span class="icon icon-dropbox" title="icon-dropbox"></span>
+      <span class="icon icon-evernote" title="icon-evernote"></span>
+      <span class="icon icon-flattr" title="icon-flattr"></span>
+      <span class="icon icon-skype" title="icon-skype"></span>
+      <span class="icon icon-skype-circled" title="icon-skype-circled"></span>
+      <span class="icon icon-renren" title="icon-renren"></span>
+      <span class="icon icon-sina-weibo" title="icon-sina-weibo"></span>
+      <span class="icon icon-paypal" title="icon-paypal"></span>
+      <span class="icon icon-picasa" title="icon-picasa"></span>
+      <span class="icon icon-soundcloud" title="icon-soundcloud"></span>
+      <span class="icon icon-mixi" title="icon-mixi"></span>
+      <span class="icon icon-behance" title="icon-behance"></span>
+      <span class="icon icon-google-circles" title="icon-google-circles"></span>
+      <span class="icon icon-vkontakte" title="icon-vkontakte"></span>
+      <span class="icon icon-smashing" title="icon-smashing"></span>
+      <span class="icon icon-sweden" title="icon-sweden"></span>
+      <span class="icon icon-db-shape" title="icon-db-shape"></span>
+      <span class="icon icon-logo-db" title="icon-logo-db"></span>
     </div>
   </body>
 </html>


### PR DESCRIPTION
To more easily find the class name of an icon, you can now hover over it, and it will be displayed. I understand that this doesn't strictly follow the [guidelines for contributing](https://github.com/connors/photon/blob/master/CONTRIBUTING.md), but I figured it was small enough that it's OK. If not, sorry.
