### PR TITLE
fix sidebar display bug

### DIFF
--- a/sass/utilities.scss
+++ b/sass/utilities.scss
@@ -103,6 +103,7 @@
 
 // Set the background-color to set a sidebar back a bit.
 .sidebar {
+  overflow: scroll;
   background-color: #f5f5f4;
 }
 


### PR DESCRIPTION
when nav's height is higher than screen‘s height, the sidebar will display white when scroll down