### PR TITLE
Fixing icon colour on button variations

### DIFF
--- a/dist/css/photon.css
+++ b/dist/css/photon.css
@@ -461,6 +461,13 @@ h6 {
   line-height: 1;
 }
 
+.btn-primary .icon,
+.btn-positive .icon,
+.btn-negative .icon,
+.btn-warning .icon {
+  color: #fff;
+}
+
 .btn .icon-text {
   margin-right: 5px;
 }

--- a/docs/dist/css/photon.css
+++ b/docs/dist/css/photon.css
@@ -461,6 +461,13 @@ h6 {
   line-height: 1;
 }
 
+.btn-primary .icon,
+.btn-positive .icon,
+.btn-negative .icon,
+.btn-warning .icon {
+  color: #fff;
+}
+
 .btn .icon-text {
   margin-right: 5px;
 }

--- a/sass/buttons.scss
+++ b/sass/buttons.scss
@@ -117,6 +117,14 @@
   line-height: 1;
 }
 
+// Icons in button variations
+.btn-primary .icon,
+.btn-positive .icon,
+.btn-negative .icon,
+.btn-warning .icon {
+  color: #fff;
+}
+
 // Add the margin next to the icon if there is text in the button too
 .btn .icon-text {
   margin-right: 5px;


### PR DESCRIPTION
Icons when used in button variations (primary, positive...) was not very noticeable due to little colour contrast. This PR tries to fix it.